### PR TITLE
tchannelPublisher: Use parent's tchannel object instead of creating a…

### DIFF
--- a/client/cherami/client.go
+++ b/client/cherami/client.go
@@ -27,10 +27,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/uber/cherami-thrift/.generated/go/cherami"
 	"github.com/uber/cherami-client-go/common"
 	"github.com/uber/cherami-client-go/common/backoff"
 	"github.com/uber/cherami-client-go/common/metrics"
+	"github.com/uber/cherami-thrift/.generated/go/cherami"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
@@ -257,7 +257,7 @@ func (c *clientImpl) CreatePublisher(request *CreatePublisherRequest) Publisher 
 	case PublisherTypeStreaming:
 		return NewPublisher(c, request.Path, request.MaxInflightMessagesPerConnection)
 	case PublisherTypeNonStreaming:
-		return newTChannelBatchPublisher(c, request.Path, c.options.Logger, c.options.MetricsReporter)
+		return newTChannelBatchPublisher(c, c.connection, request.Path, c.options.Logger, c.options.MetricsReporter)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, the batch publisher creates a new tchannel object every time its constructor is invoked. To get the maximum benefit from tchannel conn pooling & multiplexing, there should really be only one tchannel object per cherami-client. This patch contains changes to enforce this singleton tchannel constraint across all batch publishers.