### PR TITLE
Fix client-outputhost fd leak on consumer.close()

### DIFF
--- a/client/cherami/outputhostconnection.go
+++ b/client/cherami/outputhostconnection.go
@@ -173,6 +173,9 @@ func (conn *outputHostConnection) isClosed() bool {
 	return atomic.LoadInt32(&conn.closed) != 0
 }
 
+// drain reads and discards all messages on
+// the outputHostStream until it encounters
+// a read stream error
 func (conn *outputHostConnection) drain() {
 	for {
 		if _, err := conn.outputHostStream.Read(); err != nil {

--- a/client/cherami/outputhostconnection.go
+++ b/client/cherami/outputhostconnection.go
@@ -173,10 +173,10 @@ func (conn *outputHostConnection) isClosed() bool {
 	return atomic.LoadInt32(&conn.closed) != 0
 }
 
-// drain reads and discards all messages on
+// drainReadPipe reads and discards all messages on
 // the outputHostStream until it encounters
 // a read stream error
-func (conn *outputHostConnection) drain() {
+func (conn *outputHostConnection) drainReadPipe() {
 	for {
 		if _, err := conn.outputHostStream.Read(); err != nil {
 			return
@@ -221,7 +221,7 @@ func (conn *outputHostConnection) readMessagesPump() {
 			case conn.deliveryCh <- delivery:
 			case <-conn.closeChannel:
 				conn.logger.Info("close signal received, initiating readPump drain")
-				conn.drain()
+				conn.drainReadPipe()
 				return
 			}
 


### PR DESCRIPTION
When consumer.close() is called and an outputhostconnection has some messages waiting to be read on the stream/socket, the readMessagesPump() go-routine might block forever, resulting in a go-routine / fd leak. This is because readMessgesPump() blocks on the deliveryCh (which is inturn read by the application using the library). This patch does the following:

* Fixes the leak (by detecing close signal and draining the read pipe)
* Removes the streamConnection member from consumerImpl, which is no longer used
* Removes the closeConnection() helper on the consumerImpl and moves that logic within ouputhostconnection.close()