### PR TITLE
Add processing time metrics to Delivery ack/nack paths

### DIFF
--- a/client/cherami/connection_test.go
+++ b/client/cherami/connection_test.go
@@ -29,10 +29,10 @@ import (
 	_ "fmt"
 	_ "strconv"
 
-	"github.com/uber/cherami-thrift/.generated/go/cherami"
 	"github.com/uber/cherami-client-go/common"
 	"github.com/uber/cherami-client-go/common/metrics"
 	mc "github.com/uber/cherami-client-go/mocks/clients/cherami"
+	"github.com/uber/cherami-thrift/.generated/go/cherami"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
@@ -337,7 +337,19 @@ func createConnection() (*connection, *mc.MockBInOpenPublisherStreamOutCall, cha
 	inputHostClient.On("OpenPublisherStream", mock.Anything).Return(stream, nil)
 	wsConnector.On("OpenPublisherStream", mock.Anything, mock.Anything).Return(stream, nil)
 
-	return newConnection(inputHostClient, wsConnector, "/test/inputhostconnection", messagesCh, reconfigureCh, host, cherami.Protocol_WS, 0, bark.NewLoggerFromLogrus(log.StandardLogger()), metrics.NewNullReporter()), stream, messagesCh
+	return newConnection(
+			inputHostClient,
+			wsConnector,
+			"/test/inputhostconnection",
+			messagesCh,
+			reconfigureCh,
+			host,
+			cherami.Protocol_WS,
+			0,
+			bark.NewLoggerFromLogrus(log.StandardLogger()),
+			metrics.NewTestReporter(nil)),
+		stream,
+		messagesCh
 }
 
 func wrapAckInCommand(ack *cherami.PutMessageAck) *cherami.InputHostCommand {

--- a/client/cherami/outputhostconnection.go
+++ b/client/cherami/outputhostconnection.go
@@ -372,6 +372,15 @@ func (conn *outputHostConnection) Nack(ids []string) error {
 	return conn.ackClient.AckMessages(ctx, ackRequest)
 }
 
+func (conn *outputHostConnection) ReportProcessingTime(t time.Duration, ack bool) {
+	conn.reporter.RecordTimer(metrics.ProcessLatency, nil, t)
+	if ack {
+		conn.reporter.RecordTimer(metrics.ProcessAckLatency, nil, t)
+	} else {
+		conn.reporter.RecordTimer(metrics.ProcessNackLatency, nil, t)
+	}
+}
+
 func (conn *outputHostConnection) closeAcksBatchCh() {
 	conn.acksBatchLk.Lock()
 	defer conn.acksBatchLk.Unlock()

--- a/client/cherami/tchanPublisher_test.go
+++ b/client/cherami/tchanPublisher_test.go
@@ -126,7 +126,7 @@ func (s *TChanBatchPublisherSuite) TestPublishBatchSuccess() {
 	}
 }
 
-func (s *TChanBatchPublisherSuite) j() {
+func (s *TChanBatchPublisherSuite) TestPublishBatchFailure() {
 	for _, sz := range []int{1, 16, 16, 5} {
 		ackIDs := make([]string, common.MinInt(16, sz))
 		for i := range ackIDs {

--- a/common/metrics/names.go
+++ b/common/metrics/names.go
@@ -74,6 +74,12 @@ const (
 	ConsumeNumConnections = "cherami.consume.connections"
 	// ConsumeLocalCredits is the number of credit hold locally by consumer
 	ConsumeLocalCredits = "cherami.consume.credit.local"
+	// ProcessLatency is the time between the message being read by the consumer, and either acked or nacked
+	ProcessLatency = "cherami.consume.process.latency"
+	// ProcessAckLatency is the time between the message being read by the consumer and being acked
+	ProcessAckLatency = "cherami.consume.ack.latency"
+	// ProcessNackLatency is the time between the message being read by the consumer and being nacked
+	ProcessNackLatency = "cherami.consume.nack.latency"
 )
 
 // MetricDefs contains definition of metrics to its type mapping
@@ -96,4 +102,7 @@ var MetricDefs = map[MetricName]MetricType{
 	ConsumeReconfigureRate:  Counter,
 	ConsumeNumConnections:   Gauge,
 	ConsumeLocalCredits:     Gauge,
+	ProcessLatency:          Timer,
+	ProcessAckLatency:       Timer,
+	ProcessNackLatency:      Timer,
 }

--- a/common/metrics/testreporter.go
+++ b/common/metrics/testreporter.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type (
+	// TestReporter is the reporter used to analyze metrics for unit tests
+	TestReporter struct {
+		tags map[string]string
+	}
+
+	testStopWatch struct {
+		metricName string
+		reporter   *TestReporter
+		startTime  time.Time
+		elapsed    time.Duration
+	}
+)
+
+type HandlerFn func(metricName string, baseTags, tags map[string]string, value int64)
+
+var handlers = make(map[string]map[string]HandlerFn) // Key1 - metricName; Key2 - "filterTag:filterVal"
+var handlerMutex sync.RWMutex
+
+// NewTestReporter create an instance of Reporter which can be used for driver to emit metric to console
+func NewTestReporter(tags map[string]string) Reporter {
+	reporter := &TestReporter{
+		tags: mapCopy(tags),
+	}
+
+	return reporter
+}
+
+// InitMetrics is used to initialize the metrics map with the respective type
+func (r *TestReporter) InitMetrics(metricMap map[MetricName]MetricType) {
+	// This is a no-op for test reporter as it is already have a static list of metric to work with
+}
+
+// GetChildReporter creates the child reporter for this parent reporter
+func (r *TestReporter) GetChildReporter(tags map[string]string) Reporter {
+	if len(r.tags) != 0 {
+		panic(r.tags)
+	}
+
+	sr := &TestReporter{
+		tags: mapCopy(tags),
+	}
+
+	return sr
+}
+
+// GetTags returns the tags for this reporter object
+func (r *TestReporter) GetTags() map[string]string {
+	return r.tags
+}
+
+// IncCounter reports Counter metric to M3
+func (r *TestReporter) IncCounter(name string, tags map[string]string, delta int64) {
+	r.executeHandler(name, tags, delta)
+}
+
+// UpdateGauge reports Gauge type metric
+func (r *TestReporter) UpdateGauge(name string, tags map[string]string, value int64) {
+	r.executeHandler(name, tags, value)
+}
+
+func (r *TestReporter) executeHandler(name string, tags map[string]string, value int64) {
+	handlerMutex.RLock()
+	_, ok0 := handlers[``]
+	_, ok1 := handlers[name]
+	if ok0 || ok1 {
+		if allHandler2, ok2 := handlers[``][``]; ok2 { // Global handler
+			allHandler2(name, r.tags, tags, value)
+		}
+		if allHandler3, ok3 := handlers[name][``]; ok3 { // Handler for all metrics named 'name'
+			allHandler3(name, r.tags, tags, value)
+		}
+
+		// TODO: technically, this is wrong, as we don't have the local tags overriding the struct tags, but this
+		// has no practical effect in our current use of metrics, since we never override
+		for _, q := range []map[string]string{r.tags, tags} {
+			for filterTag, filterTagVal := range q {
+				key2 := filterTag + `:` + filterTagVal
+				if handler4, ok4 := handlers[``][key2]; ok4 { // Handler for this tag, any name
+					handler4(name, r.tags, tags, value)
+				}
+				if handler5, ok5 := handlers[name][key2]; ok5 { // Handler for specifically this name and tag
+					handler5(name, r.tags, tags, value)
+				}
+			}
+		}
+	}
+	handlerMutex.RUnlock()
+}
+
+// Register a handler (closure) that receives updates for a particular guage or counter based on the metric name and
+// the name/value of one of the metric's tags. If the filterTag/Val are both empty, all updates to that metric will
+// trigger the handler. If metricName is empty, all metrics matching the tag filter will pass through your function.
+// A nil handler unregisters the handler for the given filter parameters
+//
+// Dev notes:
+// * It is advisible to defer a call to unregister your handler when your test ends
+// * Your handler can be called concurrently. Capture your own sync.Mutex if you must serialize
+// * Counters report the delta; you must maintain the cumulative value of your counter if it is important
+// * Your handler executes synchronously with the metrics code; DO NOT BLOCK
+func RegisterHandler(metricName, filterTag, filterTagVal string, handler HandlerFn) {
+	defer handlerMutex.Unlock()
+	handlerMutex.Lock()
+	if _, ok := handlers[metricName]; !ok {
+		handlers[metricName] = make(map[string]HandlerFn)
+	}
+
+	key2 := filterTag + `:` + filterTagVal
+	if key2 == `:` {
+		key2 = ``
+	}
+
+	if handler == nil {
+		delete(handlers[metricName], key2)
+		if len(handlers[metricName]) == 0 {
+			delete(handlers, metricName)
+		}
+		return
+	}
+
+	if hf, ok2 := handlers[metricName][key2]; ok2 {
+		panic(fmt.Sprintf("Metrics handler %v (for '%s'/'%s') should have been unregistered", hf, metricName, key2))
+	}
+
+	handlers[metricName][key2] = handler
+}
+
+func newTestStopWatch(metricName string, reporter *TestReporter) *testStopWatch {
+	watch := &testStopWatch{
+		metricName: metricName,
+		reporter:   reporter,
+	}
+
+	return watch
+}
+
+func (w *testStopWatch) Start() {
+	w.startTime = time.Now()
+}
+
+func (w *testStopWatch) Stop() time.Duration {
+	w.elapsed = time.Since(w.startTime)
+	w.reporter.executeHandler(w.metricName, w.reporter.GetTags(), int64(w.elapsed))
+	return w.elapsed
+}
+
+// StartTimer returns a Stopwatch which when stopped will report the metric to M3
+func (r *TestReporter) StartTimer(name string, tags map[string]string) Stopwatch {
+	w := newTestStopWatch(name, r)
+	w.Start()
+	return w
+}
+
+// RecordTimer should be used for measuring latency when you cannot start the stop watch.
+func (r *TestReporter) RecordTimer(name string, tags map[string]string, d time.Duration) {
+	r.executeHandler(name, tags, int64(d))
+}
+
+func mapCopy(s map[string]string) (d map[string]string) {
+	d = make(map[string]string, len(s))
+	for a, b := range s {
+		d[a] = b
+	}
+	return
+}


### PR DESCRIPTION
We have this task to have a processing time metric for our consumers. There's some questions about what it is that we need exactly and why. I made an implementation that's purely consumer-side, here.

There were some suggestions to modify the Ack tokens to have some timing information, but I don't see a good way to do this for a couple of reasons:
1) the acks are currently idempotent; internal architecture on the outputhost doesn't easily allow each message to have many different ACK IDs, representing deliveries at different times
2) Measuring from the outputhost necessarily includes a bunch of queueing times (redelivery channel, per-connection channel, then the network buffers, then the consumer prefetch, finally the delivery channel). It seems like maybe we should measure this separately.

My pull request creates a tight measure of the consumer's processing time (at least for non-batch scenarios)