### PR TITLE
Unblock read acks pump from inputhost

### DIFF
--- a/client/cherami/connection_test.go
+++ b/client/cherami/connection_test.go
@@ -23,7 +23,6 @@ package cherami
 import (
 	"errors"
 	"io"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -224,9 +223,7 @@ func (s *ConnectionSuite) TestClientDrain() {
 
 	messagesCh <- putMessageRequest{message, requestDone}
 	<-time.After(10 * time.Millisecond)
-	// drain must be set
-	s.Equal(int32(1), atomic.LoadInt32(&conn.drained))
-	// closed must return true as well
+	// we must have drained and so closed must return true
 	s.True(conn.isClosed())
 }
 

--- a/client/cherami/publisher.go
+++ b/client/cherami/publisher.go
@@ -276,8 +276,11 @@ func (s *publisherImpl) reconfigurePublisher() {
 		for host, inputHostConn := range s.connections {
 			if _, ok := currentHosts[host]; !ok {
 				connLogger := s.logger.WithField(common.TagHostIP, common.FmtHostIP(inputHostConn.connKey))
-				connLogger.Info("Closing connection to InputHost after reconfiguration.")
-				inputHostConn.close()
+				// only close if we are not draining
+				if !inputHostConn.isDraining() {
+					connLogger.Info("Closing connection to InputHost after reconfiguration.")
+					inputHostConn.close()
+				}
 			}
 		}
 

--- a/client/cherami/publisher.go
+++ b/client/cherami/publisher.go
@@ -276,11 +276,8 @@ func (s *publisherImpl) reconfigurePublisher() {
 		for host, inputHostConn := range s.connections {
 			if _, ok := currentHosts[host]; !ok {
 				connLogger := s.logger.WithField(common.TagHostIP, common.FmtHostIP(inputHostConn.connKey))
-				// only close if we are not draining
-				if !inputHostConn.isDraining() {
-					connLogger.Info("Closing connection to InputHost after reconfiguration.")
-					inputHostConn.close()
-				}
+				connLogger.Info("Closing connection to InputHost after reconfiguration.")
+				inputHostConn.close()
 			}
 		}
 

--- a/common/metrics/names.go
+++ b/common/metrics/names.go
@@ -55,6 +55,10 @@ const (
 	PublishNumConnections = "cherami.publish.connections"
 	// PublishNumInflightMessagess is the number of inflight messages hold locally by publisher
 	PublishNumInflightMessagess = "cherami.publish.message.inflights"
+	// PublisherMessageFailed is the number of failed messages on the publisher
+	PublisherMessageFailed = "cherami.publisher.message.failed"
+	// PublisherMessageTimedout is the number of messages timed out on the publisher
+	PublisherMessageTimedout = "cherami.publisher.message.timedout"
 
 	// ConsumeMessageRate is the rate of message got from output
 	ConsumeMessageRate = "cherami.consume.message.rate"
@@ -91,8 +95,11 @@ var MetricDefs = map[MetricName]MetricType{
 	PublishMessageLatency:       Timer,
 	PublishAckRate:              Counter,
 	PublishReconfigureRate:      Counter,
+	PublishDrainRate:            Counter,
 	PublishNumConnections:       Gauge,
 	PublishNumInflightMessagess: Gauge,
+	PublisherMessageFailed:      Counter,
+	PublisherMessageTimedout:    Counter,
 
 	ConsumeMessageRate:      Counter,
 	ConsumeCreditRate:       Counter,


### PR DESCRIPTION
If the server is draining gracefully, then the server will send a
DRAIN command. The DRAIN command used to simply stop the write pump and
wait for the server to close the stream.

Even though server successfully will close the stream after finishing
the DRAIN, the readAcks pump will never see the EOF because we don't do
a stream.Read() unless we have some messages inflight.

This patch tries to solve that by waiting for a default of a minute and
explicitly closing the connection. In addition this patch also adds some
additional logs and metrics to make sure we can track retries and
failures on publish.