### PR TITLE
Nack() Delivery when OutputHostConnection IsClose()

### DIFF
--- a/client/cherami/outputhostconnection.go
+++ b/client/cherami/outputhostconnection.go
@@ -218,6 +218,11 @@ func (conn *outputHostConnection) readMessagesPump() {
 			msg := cmd.Message
 			delivery := newDelivery(msg, conn)
 
+			if conn.isClosed() {
+				delivery.Nack()
+				return
+			}
+
 			select {
 			case conn.deliveryCh <- delivery:
 			case <-conn.closeChannel:


### PR DESCRIPTION
This prevents the consumer from likely trying to write on a delivery channel is closed since IsClosed should always return true if the cherami calling code always closes the consumer before closing its delivery channel.