### PR TITLE
Backoff retry is not needed for ReadConsumerGroupHosts()

### DIFF
--- a/client/cherami/client.go
+++ b/client/cherami/client.go
@@ -323,25 +323,12 @@ func (c *clientImpl) ReadConsumerGroupHosts(path string, consumerGroupName strin
 	ctx, cancel := c.createContext()
 	defer cancel()
 
-	var result *cherami.ReadConsumerGroupHostsResult_
-	readOp := func() error {
-		var e error
-		request := &cherami.ReadConsumerGroupHostsRequest{
-			DestinationPath:   common.StringPtr(path),
-			ConsumerGroupName: common.StringPtr(consumerGroupName),
-		}
-
-		result, e = c.client.ReadConsumerGroupHosts(ctx, request)
-
-		return e
+	request := &cherami.ReadConsumerGroupHostsRequest{
+		DestinationPath:   common.StringPtr(path),
+		ConsumerGroupName: common.StringPtr(consumerGroupName),
 	}
 
-	err := backoff.Retry(readOp, c.retryPolicy, isTransientError)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return c.client.ReadConsumerGroupHosts(ctx, request)
 }
 
 func getFrontEndServiceName(deploymentStr string) string {


### PR DESCRIPTION
Some users complained that Consumer.Open() does not respect the timeout setting in the client config. After digging I found that ReadConsumerGroupHosts() has a backoff retry wrapping the thrift call. For Open() such retry is not needed. The other use of ReadConsumerGroupHosts() is in reconfiguration which itself is a big retry loop. Therefore, we don't need to have backoff retry for ReadConsumerGroupHosts().